### PR TITLE
Fix GLib loop shutdown via idle callbacks

### DIFF
--- a/src/ax_devil_rtsp/examples/cli.py
+++ b/src/ax_devil_rtsp/examples/cli.py
@@ -67,6 +67,10 @@ def client_runner(
     latency: int,
     queue: mp.Queue,
 ) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(process)d] %(asctime)s - %(levelname)s - %(message)s",
+    )
     def video_cb(pl: dict):
         queue.put({"kind": "video", **pl})
 

--- a/src/ax_devil_rtsp/examples/metadata_gstreamer.py
+++ b/src/ax_devil_rtsp/examples/metadata_gstreamer.py
@@ -234,9 +234,11 @@ class SceneMetadataClient:
     def _timeout_handler(self) -> None:
         """Handle timeout by stopping the client."""
         if not self._stop_event.is_set():
-            logger.warning(f"Timeout reached ({self.timeout}s), stopping client")
+            logger.warning(
+                "Timeout reached (%ss), stopping client", self.timeout
+            )
             self.error_count += 1
-            self.stop()
+            GLib.idle_add(self.stop)
 
     def start(self) -> None:
         """
@@ -277,7 +279,7 @@ class SceneMetadataClient:
         
         # Quit main loop
         if self.loop.is_running():
-            self.loop.quit()
+            GLib.idle_add(self.loop.quit)
         
         # Wait for loop thread to finish
         if self._loop_thread and self._loop_thread.is_alive():

--- a/src/ax_devil_rtsp/examples/video_gstreamer.py
+++ b/src/ax_devil_rtsp/examples/video_gstreamer.py
@@ -419,9 +419,11 @@ class VideoGStreamerClient:
     def _timeout_handler(self) -> None:
         """Handle timeout by stopping the client."""
         if not self._stop_event.is_set():
-            logger.warning(f"Timeout reached ({self.timeout}s), stopping client")
+            logger.warning(
+                "Timeout reached (%ss), stopping client", self.timeout
+            )
             self.error_count += 1
-            self.stop()
+            GLib.idle_add(self.stop)
 
     def start(self) -> None:
         """
@@ -462,7 +464,7 @@ class VideoGStreamerClient:
         
         # Quit main loop
         if self.loop.is_running():
-            self.loop.quit()
+            GLib.idle_add(self.loop.quit)
         
         # Wait for loop thread to finish
         if self._loop_thread and self._loop_thread.is_alive():

--- a/src/ax_devil_rtsp/gstreamer_data_grabber.py
+++ b/src/ax_devil_rtsp/gstreamer_data_grabber.py
@@ -441,9 +441,13 @@ class CombinedRTSPClient:
     def _timeout_handler(self) -> None:
         """Handle timeout by stopping the client."""
         if not self._stop_event.is_set():
-            logger.warning(f"Timeout reached ({self.timeout}s), stopping client")
-            self._report_error("Timeout", f"Client timed out after {self.timeout} seconds")
-            self.stop()
+            logger.warning(
+                "Timeout reached (%ss), stopping client", self.timeout
+            )
+            self._report_error(
+                "Timeout", f"Client timed out after {self.timeout} seconds"
+            )
+            GLib.idle_add(self.stop)
 
     def stop(self) -> None:
         """Stop the GStreamer pipeline and quit the loop."""
@@ -463,7 +467,7 @@ class CombinedRTSPClient:
         
         # Quit main loop
         if self.loop.is_running():
-            self.loop.quit()
+            GLib.idle_add(self.loop.quit)
         
         # Wait for loop thread to finish
         if self._loop_thread and self._loop_thread.is_alive():


### PR DESCRIPTION
## Summary
- avoid thread safety issues when stopping the GLib main loop
- trigger shutdown via `GLib.idle_add` from timeout handlers
- configure logging inside spawned process in CLI example

## Testing
- `pytest tests/unit/test_cli.py::TestRTSPURLBuilding::test_build_rtsp_url_basic -q`
- `pytest -q` *(fails: Failed to create GStreamer elements)*

------
https://chatgpt.com/codex/tasks/task_e_684ab933a6f48333b96ebea577401d0d