### PR TITLE
Fix CLI log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,11 @@ metadata_client.start()  # Starts streaming in current thread
 <p>
 
 ```bash
-# Display video stream in window
+# Display video stream in window at INFO level (default)
 ax-devil-rtsp video --ip 192.168.1.90 --username admin --password secret
+
+# Show only warnings and errors
+ax-devil-rtsp video --ip 192.168.1.90 --log-level WARNING
 ```
 </p>
 </details>

--- a/src/ax_devil_rtsp/examples/cli.py
+++ b/src/ax_devil_rtsp/examples/cli.py
@@ -13,18 +13,42 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="CLI for RTSP Data Retriever (video, metadata, RTP extension, session metadata)"
     )
-    parser.add_argument("--ip", help="Camera IP address (required unless --rtsp-url provided)")
+    parser.add_argument(
+        "--ip", help="Camera IP address (required unless --rtsp-url provided)"
+    )
     parser.add_argument("--username", default="", help="Device username")
     parser.add_argument("--password", default="", help="Device password")
-    parser.add_argument("--source", default="1", help="What device \"source\"/\"camera head\" to use")
+    parser.add_argument(
+        "--source", default="1", help='What device "source"/"camera head" to use'
+    )
     parser.add_argument("--latency", type=int, default=100, help="RTSP latency in ms")
-    parser.add_argument("--no-video", action="store_true", help="Disable video frames", default=False)
-    parser.add_argument("--no-metadata", action="store_true", help="Disable metadata XML", default=False)
-    parser.add_argument("--rtp-ext", action="store_true", help="Enable RTP extension", default=True)
-    parser.add_argument("--rtsp-url", help="Full RTSP URL, overrides all other arguments")
-    parser.add_argument("--log-level", default="INFO", help="Logging level")
-    parser.add_argument("--connection-timeout", type=int, default=30, help="Connection timeout in seconds")
-    parser.add_argument("--resolution", default="500x500", help="Video resolution (e.g. 1280x720)")
+    parser.add_argument(
+        "--no-video", action="store_true", help="Disable video frames", default=False
+    )
+    parser.add_argument(
+        "--no-metadata", action="store_true", help="Disable metadata XML", default=False
+    )
+    parser.add_argument(
+        "--rtp-ext", action="store_true", help="Enable RTP extension", default=True
+    )
+    parser.add_argument(
+        "--rtsp-url", help="Full RTSP URL, overrides all other arguments"
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging verbosity",
+    )
+    parser.add_argument(
+        "--connection-timeout",
+        type=int,
+        default=30,
+        help="Connection timeout in seconds",
+    )
+    parser.add_argument(
+        "--resolution", default="500x500", help="Video resolution (e.g. 1280x720)"
+    )
     return parser.parse_args()
 
 
@@ -34,7 +58,7 @@ def main():
         level=getattr(logging, args.log_level.upper(), logging.INFO),
         format="[%(process)d] %(asctime)s - %(levelname)s - %(message)s",
     )
-    
+
     if args.rtsp_url:
         rtsp_url = args.rtsp_url
     else:
@@ -95,6 +119,7 @@ def main():
         on_error=on_error,
         latency=args.latency,
         connection_timeout=args.connection_timeout,
+        log_level=getattr(logging, args.log_level.upper(), logging.INFO),
     )
 
     try:
@@ -102,17 +127,20 @@ def main():
         with retriever:
             logging.info("RTSP Data Retriever started")
             print("Press Ctrl+C to stop, or 'q' in video window to quit")
-            
+
             # Keep the main thread alive and handle keyboard interrupt
             try:
                 while retriever.is_running:
                     time.sleep(0.1)
                     # Check if OpenCV window was closed (if video is enabled)
-                    if not args.no_video and cv2.getWindowProperty("Video", cv2.WND_PROP_VISIBLE) < 1:
+                    if (
+                        not args.no_video
+                        and cv2.getWindowProperty("Video", cv2.WND_PROP_VISIBLE) < 1
+                    ):
                         break
             except KeyboardInterrupt:
                 logging.info("Interrupted by user")
-                
+
     except Exception as e:
         logging.error(f"Error running retriever: {e}")
     finally:

--- a/src/ax_devil_rtsp/gstreamer_data_grabber.py
+++ b/src/ax_devil_rtsp/gstreamer_data_grabber.py
@@ -19,12 +19,15 @@ gi.require_version("GstRtp", "1.0")
 gi.require_version("GstRtsp", "1.0")
 from gi.repository import Gst, GstRtp, GLib, GstRtsp
 
-# Ensure subprocess logging is visible
-if __name__ == "__main__" or not logging.getLogger().hasHandlers():
+# Configure basic logging only when run as a standalone script. When this
+# module is imported (e.g. through the high level retrievers) logging should
+# be configured by the parent application so that options like `--log-level`
+# work as expected.
+if __name__ == "__main__":
     logging.basicConfig(
         level=logging.DEBUG,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-        stream=sys.stdout
+        stream=sys.stdout,
     )
 
 logger = logging.getLogger("ax-devil-rtsp.CombinedRTSPClient")


### PR DESCRIPTION
## Summary
- don't override logging configuration in gstreamer module when imported
- allow passing log level to the subprocess spawned by `RtspDataRetriever`
- expose log level option in CLI examples
- document log level usage in README

## Testing
- `ruff check src/ax_devil_rtsp/rtsp_data_retrievers.py src/ax_devil_rtsp/gstreamer_data_grabber.py src/ax_devil_rtsp/examples/cli.py | head -n 20`
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685ab82101ec83339f5d686e2c7f156e