### PR TITLE
Refine video processing callback payload

### DIFF
--- a/src/ax_devil_rtsp/examples/cli.py
+++ b/src/ax_devil_rtsp/examples/cli.py
@@ -15,16 +15,17 @@ from ..rtsp_data_retrievers import (
     RtspDataRetriever,
     RtspVideoDataRetriever,
 )
-from ..utils import build_axis_rtsp_url
+from ..utils import build_axis_rtsp_url, rgb_to_bgr
 
 
 def simple_video_processing_example(
-    frame: np.ndarray, shared_config: dict
+    payload: dict, shared_config: dict
 ) -> np.ndarray:
     """
     Example video processing function that demonstrates the video_processing_fn feature.
     Adds a timestamp overlay and optionally applies brightness adjustment.
     """
+    frame = rgb_to_bgr(payload["data"])
     processed = frame.copy()
 
     # Add timestamp overlay
@@ -44,6 +45,18 @@ def simple_video_processing_example(
     cv2.putText(
         processed, frame_text, (10, 60), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 0), 1
     )
+
+    ntp_time = payload.get("latest_rtp_data", {}).get("human_time")
+    if ntp_time:
+        cv2.putText(
+            processed,
+            f"NTP: {ntp_time}",
+            (10, 90),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            (0, 255, 255),
+            1,
+        )
 
     return processed
 

--- a/src/ax_devil_rtsp/rtsp_data_retrievers.py
+++ b/src/ax_devil_rtsp/rtsp_data_retrievers.py
@@ -67,7 +67,7 @@ def _client_process(
     rtsp_url: str,
     latency: int,
     queue: mp.Queue,
-    video_processing_fn: Optional[Callable],
+    video_processing_fn: Optional[Callable[[Dict[str, Any], dict], Any]],
     shared_config: Optional[dict],
     connection_timeout: Optional[float],
     log_level: int,
@@ -155,6 +155,9 @@ class RtspDataRetriever(ABC):
         GStreamer pipeline latency in ms.
     video_processing_fn : Callable, optional
         Optional function to process video frames in the GStreamer process.
+        Called as ``video_processing_fn(payload, shared_config)`` where
+        ``payload`` contains the decoded frame and the latest RTP extension
+        data.
     shared_config : dict, optional
         Optional shared config for the video processing function.
     connection_timeout : int, default=30
@@ -173,7 +176,7 @@ class RtspDataRetriever(ABC):
         on_error: Optional[ErrorCallback] = None,
         on_session_start: Optional[SessionStartCallback] = None,
         latency: int = 200,
-        video_processing_fn: Optional[Callable] = None,
+        video_processing_fn: Optional[Callable[[Dict[str, Any], dict], Any]] = None,
         shared_config: Optional[dict] = None,
         connection_timeout: int = 30,
         log_level: Optional[int] = None,
@@ -336,7 +339,7 @@ class RtspVideoDataRetriever(RtspDataRetriever):
         on_error: Optional[ErrorCallback] = None,
         on_session_start: Optional[SessionStartCallback] = None,
         latency: int = 200,
-        video_processing_fn: Optional[Callable] = None,
+        video_processing_fn: Optional[Callable[[Dict[str, Any], dict], Any]] = None,
         shared_config: Optional[dict] = None,
         connection_timeout: int = 30,
         log_level: Optional[int] = None,
@@ -366,7 +369,7 @@ class RtspApplicationDataRetriever(RtspDataRetriever):
         on_error: Optional[ErrorCallback] = None,
         on_session_start: Optional[SessionStartCallback] = None,
         latency: int = 200,
-        video_processing_fn: Optional[Callable] = None,
+        video_processing_fn: Optional[Callable[[Dict[str, Any], dict], Any]] = None,
         shared_config: Optional[dict] = None,
         connection_timeout: int = 30,
         log_level: Optional[int] = None,

--- a/src/ax_devil_rtsp/utils.py
+++ b/src/ax_devil_rtsp/utils.py
@@ -4,6 +4,7 @@ import logging
 import re
 from typing import Dict, Any
 import urllib.parse
+import numpy as np
 
 logger = logging.getLogger("ax-devil-rtsp.utils")
 
@@ -190,4 +191,23 @@ def build_axis_rtsp_url(
         query_string = urllib.parse.urlencode(params)
         url += "?" + query_string
     return url
+
+
+def rgb_to_bgr(frame: np.ndarray) -> np.ndarray:
+    """Convert an RGB image to BGR with minimal overhead.
+
+    Parameters
+    ----------
+    frame : np.ndarray
+        Input image in RGB order with shape ``(H, W, 3)``.
+
+    Returns
+    -------
+    np.ndarray
+        New array in BGR order. The returned array is contiguous so it can be
+        used directly with OpenCV functions.
+    """
+    if frame.ndim != 3 or frame.shape[2] != 3:
+        raise ValueError("Expected RGB image with shape (H, W, 3)")
+    return np.ascontiguousarray(frame[..., ::-1])
 

--- a/tests/unit/test_color_utils_unit.py
+++ b/tests/unit/test_color_utils_unit.py
@@ -1,0 +1,13 @@
+import numpy as np
+from ax_devil_rtsp.utils import rgb_to_bgr
+
+
+def test_rgb_to_bgr_swaps_channels():
+    rgb = np.array(
+        [[[255, 0, 0], [0, 255, 0], [0, 0, 255]]], dtype=np.uint8
+    )
+    bgr = rgb_to_bgr(rgb)
+    assert np.array_equal(bgr[0, 0], [0, 0, 255])
+    assert np.array_equal(bgr[0, 1], [0, 255, 0])
+    assert np.array_equal(bgr[0, 2], [255, 0, 0])
+    assert bgr.flags["C_CONTIGUOUS"]


### PR DESCRIPTION
## Summary
- do not pass diagnostics to video processing function
- update CLI example and docs for new payload data
- add fast rgb_to_bgr helper and use in video processing demo

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d65dd854c8333a8b5a8d23f5cda84