### PR TITLE
Optimize branch initialization

### DIFF
--- a/src/ax_devil_rtsp/gstreamer/callbacks.py
+++ b/src/ax_devil_rtsp/gstreamer/callbacks.py
@@ -59,10 +59,16 @@ class CallbackHandlerMixin:
 
         media = struct.get_string("media") or ""
         if media.lower() == "application":
-            self._ensure_application_data_branch()
-            sink_pad = self.m_jit.get_static_pad('sink')
+            if self.application_data_branch_enabled:
+                self._ensure_application_data_branch()
+                sink_pad = self.m_jit.get_static_pad('sink') if self.m_jit else None
+            else:
+                sink_pad = None
         else:
-            sink_pad = self.v_depay.get_static_pad('sink')
+            if self.video_branch_enabled:
+                sink_pad = self.v_depay.get_static_pad('sink') if self.v_depay else None
+            else:
+                sink_pad = None
 
         if sink_pad and not sink_pad.is_linked():
             pad.link(sink_pad)

--- a/src/ax_devil_rtsp/gstreamer/client.py
+++ b/src/ax_devil_rtsp/gstreamer/client.py
@@ -64,6 +64,9 @@ class CombinedRTSPClient(CallbackHandlerMixin, DiagnosticMixin, PipelineSetupMix
         self.video_proc_fn = video_processing_fn
         self.shared_cfg = shared_config or {}
 
+        self.video_branch_enabled = video_frame_callback is not None or video_processing_fn is not None
+        self.application_data_branch_enabled = application_data_callback is not None
+
         # Initialize GStreamer
         Gst.init(None)
         self.loop = GLib.MainLoop()

--- a/src/ax_devil_rtsp/gstreamer/pipeline.py
+++ b/src/ax_devil_rtsp/gstreamer/pipeline.py
@@ -28,12 +28,15 @@ class PipelineSetupMixin:
         self.v_depay: Optional[Gst.Element] = None
         self.m_jit: Optional[Gst.Element] = None
         self.application_data_branch_built: bool = False
+        self.video_branch_enabled: bool = True
+        self.application_data_branch_enabled: bool = True
 
     def _setup_elements(self) -> None:
         """Set up all pipeline elements."""
         logger.debug("Setting up pipeline elements")
         self._create_rtspsrc()
-        self._create_video_branch()
+        if self.video_branch_enabled:
+            self._create_video_branch()
         self.application_data_branch_built = False
 
     def _create_rtspsrc(self) -> None:

--- a/src/ax_devil_rtsp/rtsp_data_retrievers.py
+++ b/src/ax_devil_rtsp/rtsp_data_retrievers.py
@@ -71,6 +71,8 @@ def _client_process(
     shared_config: Optional[dict],
     connection_timeout: Optional[float],
     log_level: int,
+    enable_video: bool,
+    enable_application: bool,
 ):
     """
     Subprocess target: Instantiates CombinedRTSPClient and pushes events to the queue.
@@ -111,8 +113,8 @@ def _client_process(
         client = CombinedRTSPClient(
             rtsp_url,
             latency=latency,
-            video_frame_callback=video_cb,
-            application_data_callback=application_data_cb,
+            video_frame_callback=video_cb if enable_video else None,
+            application_data_callback=application_data_cb if enable_application else None,
             stream_session_metadata_callback=session_cb,
             error_callback=error_cb,
             video_processing_fn=video_processing_fn,
@@ -218,6 +220,8 @@ class RtspDataRetriever(ABC):
                 self._shared_config,
                 self._connection_timeout,
                 self._log_level,
+                self._on_video_data is not None or self._video_processing_fn is not None,
+                self._on_application_data is not None,
             ),
         )
         self._proc.start()


### PR DESCRIPTION
## Summary
- set flags for video/application branches
- initialize GStreamer branches only when needed
- skip unused branches in `_on_pad_added`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gi')*

------
https://chatgpt.com/codex/tasks/task_e_68679340619c8333bbd643e950797f2e