### PR TITLE
Linux-first GI/GStreamer: system-manage PyGObject; add runtime check;…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ export AX_DEVIL_TARGET_USER=<username>
 export AX_DEVIL_TARGET_PASS=<password>
 export AX_DEVIL_USAGE_CLI="safe" # Set to "unsafe" to skip SSL certificate verification for CLI calls
 ```
+---
+> Note on GI/GStreamer
+>
+> On Linux, `PyGObject` and GStreamer are system packages. Install them with your distro package manager before using this library (see Development Setup below). If they are missing, the library will show a clear error with install instructions.
 
 ---
 
@@ -107,7 +111,7 @@ def frame_callback(frame, rtp_info):
 # Initialize video client with context manager
 rtsp_url = "rtsp://username:password@192.168.1.90/axis-media/media.amp"
 client = VideoGStreamerClient(rtsp_url, latency=100, frame_handler_callback=frame_callback)
-client.start()  # Starts streaming in current thread
+client.start()
 
 # Metadata Streaming Example
 def metadata_callback(xml_text):
@@ -149,10 +153,14 @@ ax-devil-rtsp metadata --ip 192.168.1.90 --username admin --password secret
 
 ---
 
-## ⚠️ Disclaimer
-
-This project is an independent, community-driven implementation and is **not** affiliated with or endorsed by Axis Communications AB. For official APIs and development resources, please refer to [Axis Developer Community](https://www.axis.com/en-us/developer).
+---
 
 ## 📄 License
 
 MIT License - See LICENSE file for details.
+
+---
+
+## ⚠️ Disclaimer
+
+This project is independent and not affiliated with Axis Communications AB. For official resources, visit [Axis developer documentation](https://developer.axis.com/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 dependencies = [
     "numpy>=1.20.0",
     "opencv-python>=4.5.0",
-    "PyGObject==3.50.0",
     "click>=8.0.0",
     "rich>=13.9.4",
 ]

--- a/src/ax_devil_rtsp/__init__.py
+++ b/src/ax_devil_rtsp/__init__.py
@@ -3,9 +3,11 @@ AX Devil RTSP - A Python package for handling RTSP streams from Axis cameras.
 """
 
 from .gstreamer_data_grabber import CombinedRTSPClient
+from .deps import ensure_gi_ready
 
 __version__ = "0.1.0"
 
 __all__ = [
     "CombinedRTSPClient",
+    "ensure_gi_ready",
 ]

--- a/src/ax_devil_rtsp/deps.py
+++ b/src/ax_devil_rtsp/deps.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""
+Minimal dependency checks and user guidance for GI/GStreamer.
+
+We avoid importing gi at top-level in other modules to keep import-time
+failures user-friendly and provide actionable messages.
+"""
+
+
+def ensure_gi_ready() -> None:
+    """Ensure PyGObject (gi) and core GStreamer introspection are available.
+
+    Raises a RuntimeError with distro-specific installation guidance when the
+    GI stack is unavailable or misconfigured.
+    """
+    try:
+        import gi  # type: ignore
+
+        # Require core namespaces used by this project
+        gi.require_version("Gst", "1.0")
+        gi.require_version("GstRtsp", "1.0")
+        gi.require_version("GstRtp", "1.0")
+
+        # Import to validate binding availability and lazy-load shared libs
+        from gi.repository import GLib, Gst, GstRtp  # type: ignore # noqa: F401
+    except Exception as exc:  # pragma: no cover - environment dependent
+        guidance = (
+            "PyGObject/GStreamer not available or incompatible.\n\n"
+            "Install system packages:\n"
+            "- Ubuntu/Debian: sudo apt install python3-gi gobject-introspection "
+            "gir1.2-gstreamer-1.0 gstreamer1.0-plugins-{base,good,bad,ugly} gstreamer1.0-libav\n"
+            "- Fedora/RHEL: sudo dnf install python3-gobject gobject-introspection "
+            "gstreamer1-plugins-{base,good,bad,ugly}-freeworld gstreamer1-libav\n"
+            "- Arch: sudo pacman -S python-gobject gobject-introspection "
+            "gst-plugins-{base,good,bad,ugly} gst-libav\n"
+            "- macOS (Homebrew): brew install gobject-introspection pygobject3 gstreamer "
+            "gst-plugins-base gst-plugins-good\n"
+            "- Windows (MSYS2): pacman -S mingw-w64-ucrt-x86_64-python-gobject "
+            "mingw-w64-ucrt-x86_64-gstreamer\n\n"
+            f"Original error: {exc}"
+        )
+        raise RuntimeError(guidance) from exc
+
+

--- a/src/ax_devil_rtsp/examples/cli.py
+++ b/src/ax_devil_rtsp/examples/cli.py
@@ -5,6 +5,8 @@ import multiprocessing as mp
 import cv2
 import urllib.parse
 
+from ..deps import ensure_gi_ready
+ensure_gi_ready()
 from ..gstreamer_data_grabber import CombinedRTSPClient
 
 

--- a/src/ax_devil_rtsp/examples/metadata_gstreamer.py
+++ b/src/ax_devil_rtsp/examples/metadata_gstreamer.py
@@ -1,11 +1,13 @@
-import gi
+import gi  # type: ignore
 import time
 import logging
 import multiprocessing
 from typing import Callable, Optional, Dict, Any
 
+from ..deps import ensure_gi_ready
+ensure_gi_ready()
 gi.require_version('Gst', '1.0')
-from gi.repository import Gst, GLib
+from gi.repository import Gst, GLib  # type: ignore
 
 logger = logging.getLogger("ax-devil-rtsp.SceneMetadataClient")
 
@@ -278,7 +280,7 @@ if __name__ == "__main__":
     )
 
     multiprocessing.set_start_method("spawn", force=True)
-    xml_queue = multiprocessing.Queue()
+    xml_queue: multiprocessing.Queue = multiprocessing.Queue()
 
     username = "username"
     password = "password"

--- a/src/ax_devil_rtsp/examples/video_gstreamer.py
+++ b/src/ax_devil_rtsp/examples/video_gstreamer.py
@@ -4,15 +4,15 @@ from datetime import datetime, timezone
 from typing import Callable, Optional, Dict, Any
 import multiprocessing
 
-import gi
+import gi  # type: ignore
 import numpy as np
 import cv2
 
 from ..utils import parse_session_metadata
+from ..deps import ensure_gi_ready
 
-gi.require_version('Gst', '1.0')
-gi.require_version('GstRtp', '1.0')
-from gi.repository import Gst, GstRtp, GLib
+ensure_gi_ready()
+from gi.repository import Gst, GstRtp, GLib  # type: ignore
 
 logger = logging.getLogger("ax-devil-rtsp.VideoGStreamerClient")
 
@@ -74,10 +74,10 @@ class VideoGStreamerClient:
         self._build_pipeline()
 
         # Initialize time spent metrics.
-        self.time_spent_rtp_probe = None
-        self.time_spent_sample = None
-        self.time_spent_custom_fn = None
-        self.time_spent_callback = None
+        self.time_spent_rtp_probe: float = 0.0
+        self.time_spent_sample: float = 0.0
+        self.time_spent_custom_fn: float = 0.0
+        self.time_spent_callback: float = 0.0
 
     def _build_pipeline(self) -> None:
         """
@@ -511,7 +511,7 @@ if __name__ == "__main__":
     )
 
     multiprocessing.set_start_method("spawn", force=True)
-    frame_queue = multiprocessing.Queue()
+    frame_queue: multiprocessing.Queue = multiprocessing.Queue()
 
     # Create a shared configuration using a Manager dict.
     manager = multiprocessing.Manager()

--- a/src/ax_devil_rtsp/gstreamer_data_grabber.py
+++ b/src/ax_devil_rtsp/gstreamer_data_grabber.py
@@ -7,14 +7,15 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional
 
 import cv2
-import gi
 import numpy as np
 
 from .utils import parse_session_metadata
+from .deps import ensure_gi_ready
 
-gi.require_version("Gst", "1.0")
-gi.require_version("GstRtp", "1.0")
-from gi.repository import Gst, GstRtp, GLib, GstRtsp
+# Fail fast with clear guidance if GI/GStreamer is not available
+ensure_gi_ready()
+import gi  # type: ignore
+from gi.repository import Gst, GstRtp, GLib, GstRtsp  # type: ignore
 
 logger = logging.getLogger("ax-devil-rtsp.CombinedRTSPClient")
 

--- a/src/ax_devil_rtsp/rtsp_data_retrievers.py
+++ b/src/ax_devil_rtsp/rtsp_data_retrievers.py
@@ -1,0 +1,397 @@
+"""
+RTSP Data Retriever Classes
+
+This module provides high-level, process-safe retrievers for video and/or application
+data from RTSP streams, with a focus on Axis cameras. Use the specialized retrievers for
+video-only, application-data-only, or combined retrieval. For Axis-style URLs, use build_axis_rtsp_url.
+
+All retrievers run the GStreamer client in a subprocess and communicate via a thread-safe queue.
+
+See Also:
+    - build_axis_rtsp_url (in ax_devil_rtsp.utils)
+    - Example usage: see the example file in the repository
+
+Note:
+    Always call stop() or use the context manager to ensure resources are cleaned up.
+"""
+
+import logging
+import multiprocessing as mp
+import threading
+import queue as queue_mod
+from typing import Callable, Optional, Dict, Any, TYPE_CHECKING
+from abc import ABC
+import os
+import traceback
+
+from .deps import ensure_gi_ready
+
+# IMPORTANT: Always use 'spawn' start method for multiprocessing to ensure
+# compatibility between parent and GStreamer subprocesses, and to avoid
+# queue breakage or deadlocks. This is required for reliable cross-process
+# communication, especially when using GStreamer and Python >=3.8.
+mp.set_start_method('spawn', force=True)
+
+RtspPayload = Dict[str, Any]
+if TYPE_CHECKING:
+    from typing import Protocol
+    class VideoDataCallback(Protocol):
+        def __call__(self, payload: RtspPayload) -> None: ...
+    class ApplicationDataCallback(Protocol):
+        def __call__(self, payload: RtspPayload) -> None: ...
+    class ErrorCallback(Protocol):
+        def __call__(self, payload: RtspPayload) -> None: ...
+    class SessionStartCallback(Protocol):
+        def __call__(self, payload: RtspPayload) -> None: ...
+else:
+    VideoDataCallback = Callable[[RtspPayload], None]
+    ApplicationDataCallback = Callable[[RtspPayload], None]
+    ErrorCallback = Callable[[RtspPayload], None]
+    SessionStartCallback = Callable[[RtspPayload], None]
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RtspPayload",
+    "VideoDataCallback",
+    "ApplicationDataCallback",
+    "ErrorCallback",
+    "SessionStartCallback",
+    "RtspDataRetriever",
+    "RtspVideoDataRetriever",
+    "RtspApplicationDataRetriever",
+]
+
+
+def _client_process(
+    rtsp_url: str,
+    latency: int,
+    queue: mp.Queue,
+    video_processing_fn: Optional[Callable],
+    shared_config: Optional[dict],
+    connection_timeout: Optional[float],
+    log_level: int,
+):
+    """
+    Subprocess target: Instantiates CombinedRTSPClient and pushes events to the queue.
+    Internal use only. Also starts a fallback thread to monitor parent process liveness.
+    """
+    import sys
+    import time
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+    parent_pid = os.getppid()
+    client_should_stop = threading.Event()
+
+    def parent_monitor_thread():
+        """Daemon thread: shuts down client if parent process dies."""
+        while not client_should_stop.is_set():
+            if os.getppid() != parent_pid:
+                logger.error("Parent process exited, shutting down client.")
+                try:
+                    client.stop()
+                except Exception:
+                    pass
+                sys.exit(0)
+            time.sleep(1)
+
+    try:
+        # Validate GI/GStreamer availability in the subprocess for clear user feedback
+        ensure_gi_ready()
+        logger.info(f"CombinedRTSPClient subprocess starting for {rtsp_url}")
+        # Import here to avoid top-level GI dependency at library import time
+        from .gstreamer import CombinedRTSPClient
+        def video_cb(payload):
+            queue.put({"kind": "video", **payload})
+        def application_data_cb(payload):
+            queue.put({"kind": "application_data", **payload})
+        def session_cb(payload):
+            queue.put({"kind": "session_start", **payload})
+        def error_cb(payload):
+            queue.put({"kind": "error", **payload})
+        client = CombinedRTSPClient(
+            rtsp_url,
+            latency=latency,
+            video_frame_callback=video_cb,
+            application_data_callback=application_data_cb,
+            stream_session_metadata_callback=session_cb,
+            error_callback=error_cb,
+            video_processing_fn=video_processing_fn,
+            shared_config=shared_config or {},
+            timeout=connection_timeout,
+        )
+        monitor = threading.Thread(target=parent_monitor_thread, daemon=True)
+        monitor.start()
+        try:
+            client.start()
+        finally:
+            client_should_stop.set()
+    except Exception as exc:
+        logger.error(f"Exception in CombinedRTSPClient subprocess: {exc}")
+        traceback.print_exc()
+        # Optionally, put an error on the queue so the parent sees it
+        if queue:
+            queue.put({
+                "kind": "error",
+                "error_type": "Initialization",
+                "message": str(exc),
+                "exception": str(exc),
+                "traceback": traceback.format_exc(),
+            })
+        sys.exit(1)
+
+
+class RtspDataRetriever(ABC):
+    """
+    Abstract base class for RTSP data retrievers. Manages process and queue thread lifecycle.
+    Not intended to be instantiated directly.
+
+    Parameters
+    ----------
+    rtsp_url : str
+        Full RTSP URL.
+    on_video_data : VideoDataCallback, optional
+        Callback for video frames. Receives a payload dict from CombinedRTSPClient.
+    on_application_data : ApplicationDataCallback, optional
+        Callback for application data. Receives a payload dict.
+    on_error : ErrorCallback, optional
+        Callback for errors. Receives a payload dict.
+    on_session_start : SessionStartCallback, optional
+        Callback for session metadata. Receives a payload dict.
+    latency : int, default=200
+        GStreamer pipeline latency in ms.
+    video_processing_fn : Callable, optional
+        Optional function to process video frames in the GStreamer process.
+    shared_config : dict, optional
+        Optional shared config for the video processing function.
+    connection_timeout : int, default=30
+        Connection timeout in seconds.
+    log_level : int, optional
+        Logging level used in the subprocess. Defaults to the parent's
+        effective logging level.
+    """
+    QUEUE_POLL_INTERVAL: float = 0.5  # seconds
+
+    def __init__(
+        self,
+        rtsp_url: str,
+        on_video_data: Optional[VideoDataCallback] = None,
+        on_application_data: Optional[ApplicationDataCallback] = None,
+        on_error: Optional[ErrorCallback] = None,
+        on_session_start: Optional[SessionStartCallback] = None,
+        latency: int = 200,
+        video_processing_fn: Optional[Callable] = None,
+        shared_config: Optional[dict] = None,
+        connection_timeout: int = 30,
+        log_level: Optional[int] = None,
+    ):
+        # Reset internal state to avoid stale references if start() is called after a crash
+        self._proc: Optional[mp.Process] = None
+        # Use a plain mp.Queue() for cross-process communication, as in the working example in gstreamer_data_grabber.py.
+        # This is robust and avoids the pitfalls of Manager().Queue() for high-throughput or large data.
+        self._queue: mp.Queue = mp.Queue()
+        self._queue_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._rtsp_url = rtsp_url
+        self._on_video_data = on_video_data
+        self._on_application_data = on_application_data
+        self._latency = latency
+        self._video_processing_fn = video_processing_fn
+        self._shared_config = shared_config
+        self._connection_timeout = connection_timeout
+        self._on_error = on_error
+        self._on_session_start = on_session_start
+        self._log_level = log_level if log_level is not None else logging.getLogger().getEffectiveLevel()
+
+    def start(self) -> None:
+        """
+        Start the retriever. Launches a subprocess for the GStreamer client and a thread to dispatch queue events to callbacks.
+        Raises RuntimeError if already started.
+        """
+        if self._proc is not None and self._proc.is_alive():
+            raise RuntimeError("Retriever already started.")
+        # Reset internal state to avoid stale references if start() is called after a crash
+        self._proc = None
+        self._queue_thread = None
+        self._stop_event.clear()
+        # Fail fast with clear guidance if GI/GStreamer is not ready
+        ensure_gi_ready()
+        logger.info("Starting retriever process...")
+        self._proc = mp.Process(
+            target=_client_process,
+            args=(
+                self._rtsp_url,
+                self._latency,
+                self._queue,
+                self._video_processing_fn,
+                self._shared_config,
+                self._connection_timeout,
+                self._log_level,
+            ),
+        )
+        self._proc.start()
+        self._queue_thread = threading.Thread(target=self._queue_dispatch_loop, daemon=True)
+        self._queue_thread.start()
+        logger.info("Retriever process started.")
+
+    def stop(self) -> None:
+        """
+        Stop the retriever. Terminates the subprocess and queue thread. Safe to call multiple times.
+        """
+        if self._proc is None:
+            return
+        logger.info("Stopping retriever process...")
+        self._stop_event.set()
+        try:
+            if self._proc.is_alive():
+                self._proc.terminate()
+                self._proc.join()
+        finally:
+            if self._queue_thread is not None and self._queue_thread.is_alive():
+                self._queue_thread.join(timeout=2)
+            self._proc = None
+            self._queue_thread = None
+        logger.info("Retriever process stopped.")
+
+    def close(self) -> None:
+        """
+        Alias for stop(). Provided for API familiarity with file-like objects.
+        """
+        self.stop()
+
+    def _queue_dispatch_loop(self) -> None:
+        """
+        Internal: Thread target. Reads from the queue and dispatches to the correct callback.
+        Handles EOFError/OSError gracefully if the parent process is dead.
+        Catches and logs exceptions in user callbacks to avoid breaking the loop.
+        """
+        wait_time_s = 10 # TODO: Move this? make it configurable?
+        MAX_EMPTY_POLLS = wait_time_s/self.QUEUE_POLL_INTERVAL
+        consecutive_empty = 0
+        while not self._stop_event.is_set():
+            if self._queue is None:
+                break
+            try:
+                item = self._queue.get(timeout=self.QUEUE_POLL_INTERVAL)
+                consecutive_empty = 0  # reset on successful read
+            except queue_mod.Empty:
+                # No item ready yet. Keep waiting unless the subprocess has exited or we are stopping.
+                if self._stop_event.is_set():
+                    break
+                # If the subprocess has died or was never started, exit to avoid busy-loop.
+                if self._proc is None or not self._proc.is_alive():
+                    logger.debug("Queue polling ended because retriever subprocess is not alive.")
+                    break
+                # Otherwise, continue polling.
+                consecutive_empty += 1
+                if consecutive_empty >= MAX_EMPTY_POLLS:
+                    logger.debug("Queue polling ended due to excessive empty polls.")
+                    break
+                continue
+            except (EOFError, OSError):
+                # Queue broken or closed due to process exit; exit the loop.
+                logger.debug("Queue polling ended due to queue closure or OS error.")
+                break
+            kind = item.get("kind")
+            try:
+                if kind == "video" and self._on_video_data:
+                    logger.debug("Dispatching video callback.")
+                    self._on_video_data(item)
+                elif kind == "application_data" and self._on_application_data:
+                    logger.debug("Dispatching application data callback.")
+                    self._on_application_data(item)
+                elif kind == "error" and self._on_error:
+                    logger.debug("Dispatching error callback.")
+                    self._on_error(item)
+                elif kind == "session_start" and self._on_session_start:
+                    logger.debug("Dispatching session_start callback.")
+                    self._on_session_start(item)
+            except Exception as exc:
+                logger.error(f"Exception in user callback for kind '{kind}': {exc}", exc_info=True)
+
+    def __enter__(self) -> "RtspDataRetriever":
+        """
+        Context manager entry. Starts the retriever.
+        """
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Context manager exit. Ensures retriever is stopped and resources are cleaned up.
+        """
+        try:
+            self.stop()
+        except Exception as e:
+            logger.error(f"Error during retriever cleanup: {e}")
+
+    @property
+    def is_running(self) -> bool:
+        """
+        Returns True if the retriever is running.
+        """
+        return self._proc is not None and self._proc.is_alive()
+
+
+
+class RtspVideoDataRetriever(RtspDataRetriever):
+    """
+    Retrieve only video data from an RTSP stream.
+    """
+    def __init__(
+        self,
+        rtsp_url: str,
+        on_video_data: Optional[VideoDataCallback] = None,
+        on_error: Optional[ErrorCallback] = None,
+        on_session_start: Optional[SessionStartCallback] = None,
+        latency: int = 200,
+        video_processing_fn: Optional[Callable] = None,
+        shared_config: Optional[dict] = None,
+        connection_timeout: int = 30,
+        log_level: Optional[int] = None,
+    ):
+        super().__init__(
+            rtsp_url=rtsp_url,
+            on_video_data=on_video_data,
+            on_application_data=None,
+            on_error=on_error,
+            on_session_start=on_session_start,
+            latency=latency,
+            video_processing_fn=video_processing_fn,
+            shared_config=shared_config,
+            connection_timeout=connection_timeout,
+            log_level=log_level,
+        )
+
+
+class RtspApplicationDataRetriever(RtspDataRetriever):
+    """
+    Retrieve only application (Axis Scene Description) data from an RTSP stream.
+    """
+    def __init__(
+        self,
+        rtsp_url: str,
+        on_application_data: Optional[ApplicationDataCallback] = None,
+        on_error: Optional[ErrorCallback] = None,
+        on_session_start: Optional[SessionStartCallback] = None,
+        latency: int = 200,
+        video_processing_fn: Optional[Callable] = None,
+        shared_config: Optional[dict] = None,
+        connection_timeout: int = 30,
+        log_level: Optional[int] = None,
+    ):
+        super().__init__(
+            rtsp_url=rtsp_url,
+            on_video_data=None,
+            on_application_data=on_application_data,
+            on_error=on_error,
+            on_session_start=on_session_start,
+            latency=latency,
+            video_processing_fn=video_processing_fn,
+            shared_config=shared_config,
+            connection_timeout=connection_timeout,
+            log_level=log_level,
+        )

--- a/tools/check_dependencies.py
+++ b/tools/check_dependencies.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Dependency Checker for ax-devil-rtsp
+
+This script verifies that all required dependencies are properly installed
+and can be imported. Useful for debugging CI/local environment issues.
+
+Usage:
+    python tools/check_dependencies.py
+"""
+
+import sys
+import os
+
+def test_import(name, description, extra_check=None):
+    """Test importing a module and print detailed result."""
+    try:
+        if name == "gi_gstreamer":
+            # Special case for GStreamer - test the full import chain
+            import gi  # type: ignore
+            print(f"  ├─ gi: ✅ (version: {getattr(gi, '__version__', 'unknown')})")
+            
+            gi.require_version("Gst", "1.0")
+            gi.require_version("GstRtspServer", "1.0")
+            print(f"  ├─ gi.require_version: ✅")
+            
+            from gi.repository import Gst, GstRtspServer, GLib  # type: ignore
+            print(f"  ├─ Gst: ✅")
+            print(f"  ├─ GstRtspServer: ✅") 
+            print(f"  └─ GLib: ✅")
+            
+            # Test GStreamer initialization
+            Gst.init(None)
+            print(f"  └─ Gst.init(): ✅")
+            
+        else:
+            module = __import__(name)
+            version = getattr(module, '__version__', 'unknown')
+            print(f"  └─ {name}: ✅ (version: {version})")
+            
+        if extra_check:
+            extra_check()
+            
+        return True
+            
+    except Exception as e:
+        print(f"  └─ {name}: ❌ FAILED - {e}")
+        return False
+
+def check_environment():
+    """Check environment variables and system info."""
+    print("=== ENVIRONMENT INFO ===")
+    print(f"Python version: {sys.version}")
+    print(f"Python executable: {sys.executable}")
+    print(f"Platform: {sys.platform}")
+    
+    # Check relevant environment variables
+    env_vars = [
+        'USE_REAL_CAMERA',
+        'AX_DEVIL_TARGET_USER', 
+        'AX_DEVIL_TARGET_PASS',
+        'AX_DEVIL_TARGET_ADDR',
+        'PYTHONPATH'
+    ]
+    
+    print(f"\n=== ENVIRONMENT VARIABLES ===")
+    for var in env_vars:
+        value = os.getenv(var, '<not set>')
+        print(f"{var}: {value}")
+
+def main():
+    """Main dependency checking routine."""
+    print("🔍 ax-devil-rtsp Dependency Checker")
+    print("=" * 50)
+    
+    check_environment()
+    
+    print(f"\n=== TESTING IMPORTS ===")
+    
+    # Define all critical imports with descriptions
+    imports_to_test = [
+        ("numpy", "NumPy - Array processing"),
+        ("cv2", "OpenCV - Computer vision library"), 
+        ("gi", "PyGObject - Python GObject bindings"),
+        ("gi_gstreamer", "GStreamer - Multimedia framework"),
+    ]
+    
+    results = {}
+    
+    for import_name, description in imports_to_test:
+        print(f"\n🔧 {description}")
+        results[import_name] = test_import(import_name, description)
+    
+    # Summary
+    print(f"\n=== SUMMARY ===")
+    failed_imports = [name for name, success in results.items() if not success]
+    
+    if failed_imports:
+        print(f"❌ FAILED IMPORTS: {', '.join(failed_imports)}")
+        print(f"\n💡 Troubleshooting:")
+        for failed in failed_imports:
+            if failed == "cv2":
+                print(f"   • Install OpenCV: pip install opencv-python")
+            elif failed == "gi":
+                print("   • Install PyGObject via your distro's package manager:")
+                print("     - Ubuntu/Debian: sudo apt install python3-gi gobject-introspection")
+                print("     - Fedora/RHEL: sudo dnf install python3-gobject gobject-introspection")
+                print("     - Arch: sudo pacman -S python-gobject gobject-introspection")
+            elif failed == "gi_gstreamer":
+                print("   • Install GStreamer and introspection packages:")
+                print("     - Ubuntu/Debian: sudo apt install gstreamer1.0-dev gstreamer1.0-plugins-\\{base,good,bad,ugly\\} gstreamer1.0-libav gir1.2-gstreamer-1.0")
+                print("     - Fedora/RHEL: sudo dnf install gstreamer1-plugins-\\{base,good,bad,ugly\\}-freeworld gstreamer1-libav gobject-introspection")
+        
+        return 1
+    else:
+        print("✅ ALL DEPENDENCIES AVAILABLE!")
+        print("🚀 Ready to run tests!")
+        return 0
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Complete installation script for ax-devil-rtsp
+# Based on analysis of .github/workflows/publish.yml, pyproject.toml, and tools/check_dependencies.py
+
+echo "🔧 Setting up ax-devil-rtsp development environment..."
+
+# Create and activate virtual environment
+echo "📦 Setting up Python virtual environment..."
+python -m pip install --upgrade pip
+python -m venv .venv
+source .venv/bin/activate
+
+# Update system packages
+echo "🔄 Updating system packages..."
+sudo apt-get update
+
+# Install core system dependencies for PyGObject and GStreamer
+echo "🛠️ Installing system dependencies..."
+sudo apt-get install -y --no-install-recommends \
+    libgirepository-2.0-dev \
+    gobject-introspection \
+    libcairo2-dev \
+    libffi-dev \
+    pkg-config \
+    gcc \
+    libglib2.0-dev
+
+# Install comprehensive GStreamer packages
+echo "🎥 Installing GStreamer packages..."
+sudo apt-get install -y \
+    gstreamer1.0-dev \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    gstreamer1.0-tools \
+    gstreamer1.0-rtsp \
+    libgstrtspserver-1.0-0
+
+# Install GObject introspection packages for GStreamer
+echo "🔗 Installing GObject introspection packages..."
+sudo apt-get install -y \
+    gir1.2-gstreamer-1.0 \
+    gir1.2-gst-plugins-base-1.0 \
+    gir1.2-gst-rtsp-server-1.0
+
+# Install additional GStreamer plugins and tools
+echo "📺 Installing additional GStreamer components..."
+sudo apt-get install -y \
+    gstreamer1.0-x \
+    gstreamer1.0-alsa \
+    gstreamer1.0-gl \
+    gstreamer1.0-gtk3 \
+    gstreamer1.0-qt5 \
+    gstreamer1.0-pulseaudio \
+    python3-gi \
+    python3-gst-1.0
+
+# Install display server for headless testing (if needed)
+echo "🖥️ Installing display server for testing..."
+sudo apt-get install -y xvfb
+
+# PyGObject is expected to come from system packages on Linux; do not install via pip by default.
+echo "🐍 Skipping pip install of PyGObject; using system packages instead."
+
+# Install project dependencies
+echo "📚 Installing project dependencies..."
+if [ -f requirements.txt ]; then 
+    echo "   Found requirements.txt, installing..."
+    pip install -r requirements.txt
+fi
+
+if [ -f requirements-dev.txt ]; then 
+    echo "   Found requirements-dev.txt, installing..."
+    pip install -r requirements-dev.txt
+fi
+
+# Install the project in development mode with dev extras
+echo "⚙️ Installing ax-devil-rtsp in development mode..."
+pip install -e .[dev]
+
+# Verify installation
+echo "🔍 Verifying installation..."
+python tools/check_dependencies.py
+
+echo "✅ Installation complete!"
+echo ""
+echo "📋 Next steps:"
+echo "   1. Activate virtual environment: source .venv/bin/activate"
+echo "   2. Run tests: pytest tests/ -v"
+echo "   3. For integration tests with real camera: USE_REAL_CAMERA=true pytest tests/integration/ -v"
+echo "   4. For local testing: USE_REAL_CAMERA=false pytest tests/ -v" 


### PR DESCRIPTION
… lazy import; docs/tools updates

- Remove PyGObject from pip deps in pyproject (treat as system package on Linux).
- Add deps.ensure_gi_ready() with distro-specific guidance.
- Call ensure_gi_ready() before starting retriever; validate in subprocess; lazy-import CombinedRTSPClient.
- tools/install_dependencies.sh: stop pip-installing PyGObject; rely on distro packages.
- tools/check_dependencies.py: clearer guidance for gi/GStreamer installs; type-ignore gi imports.
- README: note about system-managed GI/GStreamer in Installation.