### PR TITLE
Revert logger normalization changes

### DIFF
--- a/src/ax_devil_rtsp/cli/main.py
+++ b/src/ax_devil_rtsp/cli/main.py
@@ -104,7 +104,7 @@ def _display_loop(video_frames, args, retriever, logger):
 def main(**kwargs):
     args = SimpleNamespace(**kwargs)
     init_app_logging(debug=args.log_level.upper() == "DEBUG")
-    logger = get_logger("cli")
+    logger = get_logger(__name__)
     logger.info(f"Starting with args: {args}")
 
     if getattr(args, "rtsp_url", None):

--- a/src/ax_devil_rtsp/gstreamer/callbacks.py
+++ b/src/ax_devil_rtsp/gstreamer/callbacks.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Optional
 
 from ..logging import get_logger
 
-logger = get_logger("gstreamer.callbacks")
+logger = get_logger(__name__)
 
 
 gi.require_version("Gst", "1.0")

--- a/src/ax_devil_rtsp/gstreamer/client.py
+++ b/src/ax_devil_rtsp/gstreamer/client.py
@@ -20,7 +20,7 @@ gi.require_version("Gst", "1.0")
 gi.require_version("GLib", "2.0")
 
 
-logger = get_logger("gstreamer.client")
+logger = get_logger(__name__)
 
 
 class CombinedRTSPClient(CallbackHandlerMixin, DiagnosticMixin, PipelineSetupMixin):

--- a/src/ax_devil_rtsp/gstreamer/diagnostics.py
+++ b/src/ax_devil_rtsp/gstreamer/diagnostics.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional
 
 from ..logging import get_logger
 
-logger = get_logger("gstreamer.diagnostics")
+logger = get_logger(__name__)
 
 
 class DiagnosticMixin:

--- a/src/ax_devil_rtsp/gstreamer/pipeline.py
+++ b/src/ax_devil_rtsp/gstreamer/pipeline.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from ..logging import get_logger
 
-logger = get_logger("gstreamer.pipeline")
+logger = get_logger(__name__)
 
 
 gi.require_version("Gst", "1.0")

--- a/src/ax_devil_rtsp/gstreamer/utils.py
+++ b/src/ax_devil_rtsp/gstreamer/utils.py
@@ -15,7 +15,7 @@ import numpy as np
 gi.require_version("Gst", "1.0")
 
 
-logger = get_logger("gstreamer.utils")
+logger = get_logger(__name__)
 
 
 def _map_buffer(buf: Gst.Buffer) -> tuple[bool, Gst.MapInfo]:

--- a/src/ax_devil_rtsp/rtsp_data_retrievers.py
+++ b/src/ax_devil_rtsp/rtsp_data_retrievers.py
@@ -55,7 +55,7 @@ else:
     SessionStartCallback = Callable[[RtspPayload], None]
 
 
-logger = get_logger("rtsp_data_retrievers")
+logger = get_logger(__name__)
 
 __all__ = [
     "RtspPayload",

--- a/src/ax_devil_rtsp/setup_workarounds/libproxy_segfault.py
+++ b/src/ax_devil_rtsp/setup_workarounds/libproxy_segfault.py
@@ -130,7 +130,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from ..logging import get_logger
 
-logger = get_logger("setup_workarounds.libproxy_segfault")
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/ax_devil_rtsp/utils.py
+++ b/src/ax_devil_rtsp/utils.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 from .logging import get_logger
 
-logger = get_logger("utils")
+logger = get_logger(__name__)
 
 
 def parse_axis_scene_metadata_xml(xml_data: bytes) -> dict:

--- a/tests/enhanced_rtsp_server.py
+++ b/tests/enhanced_rtsp_server.py
@@ -19,7 +19,7 @@ from contextlib import closing
 from typing import Optional
 from ax_devil_rtsp.logging import get_logger
 
-logger = get_logger("enhanced_rtsp_server")
+logger = get_logger(__name__)
 
 gi.require_version("Gst", "1.0")
 gi.require_version("GstRtspServer", "1.0") 


### PR DESCRIPTION
## Summary
- restore the original get_logger implementation in the logging module, undoing the namespace normalization changes

## Testing
- PYTHONPATH=src pytest *(fails: ModuleNotFoundError: No module named 'gi')*


------
https://chatgpt.com/codex/tasks/task_e_68e64969ce6c8333b5f095e8dc82f6ea